### PR TITLE
Fix for  Pop-up blocked by browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,20 @@ app.run(['GAuth', 'GApi', 'GData', '$state', '$rootScope',
         GAuth.setClient(CLIENT);
         GAuth.setScope("https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.readonly"); // default scope is only https://www.googleapis.com/auth/userinfo.email
 
-        GAuth.checkAuth().then(
-            function (user) {
-                console.log(user.name + 'is login')
-                $state.go('webapp.home'); // an example of action if it's possible to
-                			  // authenticate user at startup of the application
-            },
-            function() {
-		        $state.go('login');       // an example of action if it's impossible to
-					  // authenticate user at startup of the application
-            }
-        );
-
+	// load the auth api
+	GApi.load('oauth2', 'v2').then(function(resp) {
+	        GAuth.checkAuth().then(
+	            function (user) {
+	                console.log(user.name + 'is login')
+	                $state.go('webapp.home'); // an example of action if it's possible to
+	                			  // authenticate user at startup of the application
+	            },
+	            function() {
+			        $state.go('login');       // an example of action if it's impossible to
+						  // authenticate user at startup of the application
+	            }
+	        );
+        });
     }
 ]);
 ```
@@ -163,6 +165,7 @@ app.controller('myController', ['$scope', 'GApi',
 
 ### Signup with google
 
+The login should be triggered by a user action, or you might run into issues with popup blockers. More information about this can be found in the [Google APIs Client Library Documentation](https://developers.google.com/api-client-library/javascript/features/authentication#specifying-your-client-id-and-scopes).
 ```javascript
 app.controller('myController', ['$scope', 'GAuth', '$state',
     function myController($scope, GAuth, $state) {

--- a/README.md
+++ b/README.md
@@ -78,20 +78,24 @@ app.run(['GAuth', 'GApi', 'GData', '$state', '$rootScope',
         GAuth.setClient(CLIENT);
         GAuth.setScope("https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.readonly"); // default scope is only https://www.googleapis.com/auth/userinfo.email
 
-	// load the auth api
-	GApi.load('oauth2', 'v2').then(function(resp) {
-	        GAuth.checkAuth().then(
-	            function (user) {
-	                console.log(user.name + 'is login')
-	                $state.go('webapp.home'); // an example of action if it's possible to
-	                			  // authenticate user at startup of the application
-	            },
-	            function() {
-			        $state.go('login');       // an example of action if it's impossible to
-						  // authenticate user at startup of the application
-	            }
-	        );
-        });
+	// load the auth api so that it doesn't have to be loaded asynchronously
+	// when the user clicks the 'login' button. 
+	// That would lead to popup blockers blocking the auth window
+	GAuth.load();
+	
+	// or just call checkAuth, which in turn does load the oauth api.
+	// if you do that, GAuth.load(); is unnecessary
+        GAuth.checkAuth().then(
+            function (user) {
+                console.log(user.name + 'is login')
+                $state.go('webapp.home'); // an example of action if it's possible to
+                			  // authenticate user at startup of the application
+            },
+            function() {
+		        $state.go('login');       // an example of action if it's impossible to
+					  // authenticate user at startup of the application
+            }
+        );
     }
 ]);
 ```

--- a/src/factories/GAuth.factory.js
+++ b/src/factories/GAuth.factory.js
@@ -25,17 +25,14 @@
             }
 
             function signin(mode, authorizeCallback) {
-
-                load().then(function (){
-                    var config = {client_id: CLIENT_ID, scope: SCOPE, immediate: false, authuser: -1, response_type: RESPONSE_TYPE};
-                    if(mode) {
-                        config.user_id = GData.getUserId();
-                        config.immediate = true;
-                    }
-                    if(DOMAIN != undefined)
-                        config.hd = DOMAIN;
-                    $window.gapi.auth.authorize(config, authorizeCallback);
-                });
+                var config = {client_id: CLIENT_ID, scope: SCOPE, immediate: false, authuser: -1, response_type: RESPONSE_TYPE};
+                if(mode) {
+                    config.user_id = GData.getUserId();
+                    config.immediate = true;
+                }
+                if(DOMAIN != undefined)
+                    config.hd = DOMAIN;
+                $window.gapi.auth.authorize(config, authorizeCallback);
             }
 
             function offline() {

--- a/src/factories/GAuth.factory.js
+++ b/src/factories/GAuth.factory.js
@@ -25,14 +25,25 @@
             }
 
             function signin(mode, authorizeCallback) {
-                var config = {client_id: CLIENT_ID, scope: SCOPE, immediate: false, authuser: -1, response_type: RESPONSE_TYPE};
-                if(mode) {
-                    config.user_id = GData.getUserId();
-                    config.immediate = true;
+                function executeSignin(mode, authorizeCallback){
+                    var config = {client_id: CLIENT_ID, scope: SCOPE, immediate: false, authuser: -1, response_type: RESPONSE_TYPE};
+                    if(mode) {
+                        config.user_id = GData.getUserId();
+                        config.immediate = true;
+                    }
+                    if(DOMAIN != undefined)
+                        config.hd = DOMAIN;
+                    $window.gapi.auth.authorize(config, authorizeCallback);
                 }
-                if(DOMAIN != undefined)
-                    config.hd = DOMAIN;
-                $window.gapi.auth.authorize(config, authorizeCallback);
+                
+                if(!mode && isLoad === true){
+                    // don't break the caller stack with async tasks
+                    executeSignin(mode, authorizeCallback);
+                } else {
+                    load().then(function (){
+                        executeSignin(mode, authorizeCallback);
+                    });
+                }
             }
 
             function offline() {
@@ -103,6 +114,8 @@
                 setScope: function(scope) {
                     SCOPE = scope;
                 },
+                
+                load: load,
 
                 checkAuth: function(){
                     var deferred = $q.defer();


### PR DESCRIPTION
This is in direct response to the issue maximepvrt/angular-google-gapi#31

All it does is removing the asynchronous loader behavior of checkAuth and login().
However, I think the best solution would be to make them behave differently. While it's ok for checkAuth to do the loading, login() should always be called directly. This ensures that login() is still called in "user action mode" whenan action is raised by a button event. The asynchronous loading prevents that and leads to browser blocking the auth-popup.
